### PR TITLE
Align Cargo.toml/Cargo.lock (clap:4.5.37->4.5.38)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4.5.36", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 assert_cmd = { version = "2.0.13" }
 predicates = { version = "3.1.3" }
 proc-macro2 = { version = "1.0.94" }


### PR DESCRIPTION
Resolves: #322

## Summary by Sourcery

Build:
- Update clap dependency version from 4.5.36 to 4.5.38 in Cargo.toml.